### PR TITLE
feat/#35 장바구니 CRUD Server Actions 구현

### DIFF
--- a/docs/milestones/issues/35.md
+++ b/docs/milestones/issues/35.md
@@ -1,0 +1,49 @@
+# #35 장바구니 CRUD API 구현
+
+## 이슈 정보
+
+| 항목 | 내용 |
+|------|------|
+| 마일스톤 | Phase 1 - 백엔드 도입 및 데이터 영속화 |
+| 목표 | 현재 화면에서 필요한 장바구니 관련 Server Actions 구현 |
+| 브랜치 | `feat/#35` |
+| 참고 | UI 변경 없음. 데이터 저장소만 localStorage → Supabase로 전환하기 위한 API 레이어 구축 |
+
+## 스코프 정의
+
+### 현재 화면에서 필요한 기능만 구현
+| 화면 | 필요한 API |
+|------|-----------|
+| `/createCart` | 세션 생성/조회, 장바구니 생성 |
+| `/shopping/[id]` | 장바구니 단건 조회, 상태 수정 |
+
+### Phase 3으로 미룬 기능
+- 장바구니 목록 조회 (getBySessionId) — 목록 페이지와 함께
+- 장바구니 삭제 (delete) — 목록 페이지와 함께
+
+## 작업 단계
+
+### Step 1. 세션 관련 Server Actions 구현
+- `src/actions/sessions/sessionActions.ts`
+- `createSession`: 익명 세션 생성 → sessions 테이블에 insert 후 반환
+- `getSession`: 세션 ID로 세션 조회
+- 상태: ✅ 완료
+
+### Step 2. 장바구니 Server Actions 구현
+- `src/actions/carts/cartActions.ts`
+- `createCart`: 장바구니 생성 (session_id, title, memo) → CREATED 상태로 insert
+- `getCartById`: 장바구니 단건 조회 (id)
+- `updateCart`: 장바구니 수정 (title, memo, status) → updated_at 자동 갱신
+- 상태: ✅ 완료
+
+### Step 3. 빌드 검증
+- `pnpm build` 정상 완료 확인
+- 상태: ✅ 완료
+
+## 진행 기록
+
+### 2026-03-30
+- 스코프 재정의: 현재 화면에서 필요한 기능만 구현 (목록 조회/삭제는 Phase 3으로)
+- 세션 Actions 구현: createSession, getSession
+- 장바구니 Actions 구현: createCart, getCartById, updateCart
+- 빌드 검증 완료

--- a/docs/milestones/phase1.md
+++ b/docs/milestones/phase1.md
@@ -14,7 +14,7 @@
 |-----------|-------|-------------|------|
 | #33 | Supabase 프로젝트 세팅 및 Next.js 연동 | Supabase 프로젝트 생성, 환경변수 설정, Supabase Client 유틸 구성, Next.js와 연동 확인 | ✅ 완료 |
 | #34 | DB 테이블 스키마 설계 및 생성 | 현재 localStorage 데이터 모델(CartItemType 등)을 분석하여 Supabase 테이블 스키마 설계 및 생성. 익명 세션 ID 기반 데이터 식별 포함 | ✅ 완료 |
-| #35 | 장바구니 CRUD API 구현 | 장바구니 생성/조회/수정/삭제 Server Actions 구현 | ⬜ 미착수 |
+| #35 | 장바구니 CRUD API 구현 | 장바구니 생성/조회/수정/삭제 Server Actions 구현 | ✅ 완료 |
 | #36 | 품목(CartItem) CRUD API 구현 | 품목 추가/조회/수정/삭제 Server Actions 구현 | ⬜ 미착수 |
 | #37 | 프론트엔드 localStorage → Supabase 마이그레이션 | 기존 localStorage 기반 로직을 Supabase API 호출로 전환, 동작 검증 | ⬜ 미착수 |
 

--- a/src/actions/carts/cartActions.ts
+++ b/src/actions/carts/cartActions.ts
@@ -1,0 +1,39 @@
+'use server';
+
+import { supabase } from '@/utils/supabaseUtil';
+import { CART_STATUS } from '@/enums/carts/cartEnums';
+
+export const createCart = async (sessionId: string, title: string, memo?: string) => {
+  const { data, error } = await supabase
+    .from('carts')
+    .insert({
+      session_id: sessionId,
+      title,
+      memo: memo || null,
+      status: CART_STATUS.CREATED,
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data;
+};
+
+export const getCartById = async (cartId: number) => {
+  const { data, error } = await supabase.from('carts').select('*').eq('id', cartId).single();
+
+  if (error) throw new Error(error.message);
+  return data;
+};
+
+export const updateCart = async (cartId: number, updates: { title?: string; memo?: string; status?: CART_STATUS }) => {
+  const { data, error } = await supabase
+    .from('carts')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', cartId)
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data;
+};

--- a/src/actions/sessions/sessionActions.ts
+++ b/src/actions/sessions/sessionActions.ts
@@ -1,0 +1,17 @@
+'use server';
+
+import { supabase } from '@/utils/supabaseUtil';
+
+export const createSession = async () => {
+  const { data, error } = await supabase.from('sessions').insert({}).select().single();
+
+  if (error) throw new Error(error.message);
+  return data;
+};
+
+export const getSession = async (sessionId: string) => {
+  const { data, error } = await supabase.from('sessions').select('*').eq('id', sessionId).single();
+
+  if (error) throw new Error(error.message);
+  return data;
+};


### PR DESCRIPTION
# Summary                                                                                          
  - 세션 Server Actions 구현 (createSession, getSession)                                              
  - 장바구니 Server Actions 구현 (createCart, getCartById, updateCart)                                
  - 현재 화면에서 필요한 기능만 스코프 한정 (목록 조회/삭제는 Phase 3)                                
                                                                                                      
  ## Test plan                                                                                        
  - [x] `pnpm build` 정상 완료 확인  