### PR TITLE
bugFix/#43 글로벌 not-found 서버 컴포넌트 분리 (React Client Manifest 에러 수정)

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,32 +1,5 @@
-'use client';
-
-import ButtonAtom from '@/atoms/buttons/ButtonAtom';
-import TitleTextAtom from '@/atoms/texts/TitleTextAtom';
-import useBackButton from '@/hooks/header/useBackButton';
-import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import NotFoundComp from '@/components/notFound/NotFoundComp';
 
 export default function NotFound() {
-  const router = useRouter();
-  const { hideBackButton, showBackButton } = useBackButton();
-
-  useEffect(() => {
-    hideBackButton();
-    return () => showBackButton();
-  }, [hideBackButton, showBackButton]);
-
-  const handleClickGoHome = () => {
-    router.push('/');
-  };
-
-  return (
-    <div className="min-h-[calc(100vh-97px)] w-full flex flex-col items-center justify-center h-full py-10 gap-3">
-      <Image src={'/images/logo.png'} width={50} height={40} alt="logo" />
-      <TitleTextAtom underline>유효하지 않은 페이지 입니다!</TitleTextAtom>
-      <ButtonAtom className="mt-10" onClick={handleClickGoHome}>
-        홈으로 돌아가기
-      </ButtonAtom>
-    </div>
-  );
+  return <NotFoundComp />;
 }

--- a/src/app/shopping/[id]/not-found.tsx
+++ b/src/app/shopping/[id]/not-found.tsx
@@ -1,32 +1,5 @@
-'use client';
-
-import ButtonAtom from '@/atoms/buttons/ButtonAtom';
-import TitleTextAtom from '@/atoms/texts/TitleTextAtom';
-import useBackButton from '@/hooks/header/useBackButton';
-import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import NotFoundComp from '@/components/notFound/NotFoundComp';
 
 export default function NotFound() {
-  const router = useRouter();
-  const { hideBackButton, showBackButton } = useBackButton();
-
-  useEffect(() => {
-    hideBackButton();
-    return () => showBackButton();
-  }, [hideBackButton, showBackButton]);
-
-  const handleClickGoHome = () => {
-    router.push('/');
-  };
-
-  return (
-    <div className="min-h-[calc(100vh-97px)] w-full flex flex-col items-center justify-center h-full py-10 gap-3">
-      <Image src={'/images/logo.png'} width={50} height={40} alt="logo" />
-      <TitleTextAtom underline>유효하지 않은 페이지 입니다!</TitleTextAtom>
-      <ButtonAtom className="mt-10" onClick={handleClickGoHome}>
-        홈으로 돌아가기
-      </ButtonAtom>
-    </div>
-  );
+  return <NotFoundComp />;
 }

--- a/src/components/notFound/NotFoundComp.tsx
+++ b/src/components/notFound/NotFoundComp.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import ButtonAtom from '@/atoms/buttons/ButtonAtom';
+import TitleTextAtom from '@/atoms/texts/TitleTextAtom';
+import useBackButton from '@/hooks/header/useBackButton';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+const NotFoundComp = () => {
+  const router = useRouter();
+  const { hideBackButton, showBackButton } = useBackButton();
+
+  useEffect(() => {
+    hideBackButton();
+    return () => showBackButton();
+  }, [hideBackButton, showBackButton]);
+
+  const handleClickGoHome = () => {
+    router.push('/');
+  };
+
+  return (
+    <div className="min-h-[calc(100vh-97px)] w-full flex flex-col items-center justify-center h-full py-10 gap-3">
+      <Image src={'/images/logo.png'} width={50} height={40} alt="logo" />
+      <TitleTextAtom underline>유효하지 않은 페이지 입니다!</TitleTextAtom>
+      <ButtonAtom className="mt-10" onClick={handleClickGoHome}>
+        홈으로 돌아가기
+      </ButtonAtom>
+    </div>
+  );
+};
+
+export default NotFoundComp;


### PR DESCRIPTION
## Summary                                                                                          
  - 글로벌 not-found.tsx에서 'use client' 사용 시 React Client Manifest 에러 발생                     
  - NotFoundComp 클라이언트 컴포넌트를 분리하여 not-found.tsx는 서버 컴포넌트로 유지                  
  - shopping/[id]/not-found.tsx도 동일하게 NotFoundComp 재사용으로 통일